### PR TITLE
Add: ax to Observability & Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@
 
 | Tool | Description | Stars |
 |------|-------------|-------|
+| [ax](https://github.com/Necmttn/ax) | Local telemetry, recall, cost, and skill analytics for AI coding agents | ![Stars](https://img.shields.io/github/stars/Necmttn/ax?style=flat-square) |
 | [Langfuse](https://github.com/langfuse/langfuse) | Open-source LLM observability | ![Stars](https://img.shields.io/github/stars/langfuse/langfuse?style=flat-square) |
 | [Phoenix](https://github.com/Arize-ai/phoenix) | AI observability & evaluation | ![Stars](https://img.shields.io/github/stars/Arize-ai/phoenix?style=flat-square) |
 | [Helicone](https://github.com/Helicone/helicone) | Open-source LLM observability | ![Stars](https://img.shields.io/github/stars/Helicone/helicone?style=flat-square) |


### PR DESCRIPTION
## What changed

- Add ax to Observability & Monitoring.
- Use the existing table and GitHub stars badge format.

## Why

ax gives AI coding-agent teams a local way to inspect session telemetry, recall, cost, and skill usage across tools like Claude Code and Codex.

## Verification

- `git diff --check`
- `npx --yes markdown-link-check README.md -c .github/workflows/link-check-config.json`
- `curl -L --max-time 20 -o /dev/null -s -w 'repo %{http_code} %{url_effective}\\n' https://github.com/Necmttn/ax`
- `curl -L --max-time 20 -o /dev/null -s -w 'badge %{http_code} %{url_effective}\\n' 'https://img.shields.io/github/stars/Necmttn/ax?style=flat-square'`

Note: `npx --yes awesome-lint README.md` fails on the current upstream README with existing table/TOC/license style issues unrelated to this row.

---

_Generated with [ax](https://github.com/Necmttn/ax)._